### PR TITLE
Fix wrong return value for getHashType() in SHA3 tests

### DIFF
--- a/app/src/androidTest/java/com/smlnskgmail/jaman/hashchecker/calculator/jdk/sha3/SHA3256JdkHashCalculatorTest.java
+++ b/app/src/androidTest/java/com/smlnskgmail/jaman/hashchecker/calculator/jdk/sha3/SHA3256JdkHashCalculatorTest.java
@@ -10,7 +10,7 @@ public class SHA3256JdkHashCalculatorTest extends BaseJdkHashCalculatorTest {
     @NonNull
     @Override
     protected HashType getHashType() {
-        return HashType.SHA_256;
+        return HashType.SHA3_256;
     }
 
     @NonNull

--- a/app/src/androidTest/java/com/smlnskgmail/jaman/hashchecker/calculator/jdk/sha3/SHA3384JdkHashCalculatorTest.java
+++ b/app/src/androidTest/java/com/smlnskgmail/jaman/hashchecker/calculator/jdk/sha3/SHA3384JdkHashCalculatorTest.java
@@ -10,7 +10,7 @@ public class SHA3384JdkHashCalculatorTest extends BaseJdkHashCalculatorTest {
     @NonNull
     @Override
     protected HashType getHashType() {
-        return HashType.SHA_384;
+        return HashType.SHA3_384;
     }
 
     @NonNull

--- a/app/src/androidTest/java/com/smlnskgmail/jaman/hashchecker/calculator/jdk/sha3/SHA3512JdkHashCalculatorTest.java
+++ b/app/src/androidTest/java/com/smlnskgmail/jaman/hashchecker/calculator/jdk/sha3/SHA3512JdkHashCalculatorTest.java
@@ -10,7 +10,7 @@ public class SHA3512JdkHashCalculatorTest extends BaseJdkHashCalculatorTest {
     @NonNull
     @Override
     protected HashType getHashType() {
-        return HashType.SHA_512;
+        return HashType.SHA3_512;
     }
 
     @NonNull

--- a/app/src/main/java/com/smlnskgmail/jaman/hashchecker/components/settings/impl/SharedPreferencesSettings.java
+++ b/app/src/main/java/com/smlnskgmail/jaman/hashchecker/components/settings/impl/SharedPreferencesSettings.java
@@ -243,7 +243,7 @@ public class SharedPreferencesSettings implements Settings {
         return sharedPreferences.getInt(key, 0);
     }
 
-    public static abstract class SharedPreferencesSettingsKeyExtractor {
+    public abstract static class SharedPreferencesSettingsKeyExtractor {
 
         @NonNull
         public abstract String extractById(@StringRes int id);

--- a/app/src/main/java/com/smlnskgmail/jaman/hashchecker/features/settings/view/lists/weblinks/WebLink.java
+++ b/app/src/main/java/com/smlnskgmail/jaman/hashchecker/features/settings/view/lists/weblinks/WebLink.java
@@ -14,7 +14,11 @@ public enum WebLink implements ListItem {
 
     SOURCE_CODE(R.string.title_web_link_github, R.drawable.ic_github, R.string.web_link_source_code),
     GOOGLE_PLAY(R.string.title_web_link_google_play, R.drawable.ic_google_play, R.string.web_link_my_apps),
-    PRIVACY_POLICY(R.string.settings_title_privacy_policy, R.drawable.ic_settings_privacy_policy, R.string.web_link_privacy_policy),
+    PRIVACY_POLICY(
+            R.string.settings_title_privacy_policy,
+            R.drawable.ic_settings_privacy_policy,
+            R.string.web_link_privacy_policy
+    ),
 
     ADAPTIVERECYCLERVIEW(
             R.string.library_name_adaptiverecyclerview,


### PR DESCRIPTION
## Checklist

__Common__

- [ ] I am ran the app before creating PR
- [ ] I am ran all tests before creating PR

__UI__

- [ ] I am ran the app for visual checks.

__Logic__

- [ ] I am tested basic app functionality.

## Changes

Describe all changes here:

- Some of the SHA3 tests were returning SHA2 `HashType` for getHashType(). I replaced them with the correct SHA3 `HashType`.
- Formatted code to comply with checkstyle

## Comments

nil
