### PR TITLE
2023-06-27 Added: feature to remove the clipboard.

### DIFF
--- a/app/src/main/java/com/smlnskgmail/jaman/hashchecker/components/clipboard/Clipboard.java
+++ b/app/src/main/java/com/smlnskgmail/jaman/hashchecker/components/clipboard/Clipboard.java
@@ -3,6 +3,8 @@ package com.smlnskgmail.jaman.hashchecker.components.clipboard;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.os.Handler;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -12,17 +14,28 @@ public class Clipboard {
 
     private final Context context;
     private final String text;
+    private final ClipboardManager clipboard;
+    private final Handler handler = new Handler();
+    private final Runnable runnable = this::clear;
 
     public Clipboard(@NonNull Context context, @NonNull String text) {
         this.context = context;
         this.text = text;
+        this.clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
     }
 
     public void copy() {
-        ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
         if (clipboard != null) {
             clipboard.setPrimaryClip(ClipData.newPlainText(context.getString(R.string.common_app_name), text));
+            handler.removeCallbacks(runnable);
+            handler.postDelayed(runnable, 60000);
         }
+    }
+
+    private void clear() {
+        ClipData clipData = ClipData.newPlainText(context.getString(R.string.common_app_name), "");
+        Log.i("Clipboard", "Remove Clipboard Text with (Label) : " + context.getString(R.string.common_app_name));
+        clipboard.setPrimaryClip(clipData);
     }
 
 }

--- a/app/src/main/java/com/smlnskgmail/jaman/hashchecker/components/clipboard/Clipboard.java
+++ b/app/src/main/java/com/smlnskgmail/jaman/hashchecker/components/clipboard/Clipboard.java
@@ -28,7 +28,7 @@ public class Clipboard {
         if (clipboard != null) {
             clipboard.setPrimaryClip(ClipData.newPlainText(context.getString(R.string.common_app_name), text));
             handler.removeCallbacks(runnable);
-            handler.postDelayed(runnable, 60000);
+            handler.postDelayed(runnable, 60_000);
         }
     }
 


### PR DESCRIPTION
## Checklist

### Common

- [x] I am ran the app before creating PR
- [x] I am ran all tests before creating PR

### UI

- [x] I am ran the app for visual checks.

### Logic

- [x] I am tested basic app functionality.

## Changes

Describe all changes here:

- Created a clear method for clearing primary clipboard;
- Use Handler to delay the method by 60 sec;

## Comments

clipboard.setPrimaryClip(clipData) sets the primary clip of the clipboard with the provided ClipData, The clipboard history is managed by the Android system and is not directly accessible to individual apps.
